### PR TITLE
Mixin for paper-dialog

### DIFF
--- a/raml-request-panel.html
+++ b/raml-request-panel.html
@@ -289,6 +289,10 @@ This property will be propagated to all sub-elements that uses this property to 
     paper-spinner {
       margin-right: 8px;
     }
+      
+    paper-dialog {
+      @apply(--raml-request-panel-popup);
+    }
 
     .panel-warning {
       width: 16px;


### PR DESCRIPTION
`--raml-request-panel-popup` mixin used for styling and positioning of auth dialog in raml-request-panel